### PR TITLE
Updated BND to latest version

### DIFF
--- a/ipojo-plugin/build.gradle
+++ b/ipojo-plugin/build.gradle
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'org.apache.felix:org.apache.felix.ipojo.manipulator:1.12.0'
+    compile 'org.apache.felix:org.apache.felix.ipojo.manipulator:1.12.1'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 

--- a/osgi-run-core/build.gradle
+++ b/osgi-run-core/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'idea'
 sourceCompatibility = 1.7
 
 group = 'com.athaydes.gradle.osgi'
-version = '1.3.1'
+version = '1.4.0'
 
 repositories {
     jcenter()
@@ -27,7 +27,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile group: 'biz.aQute.bnd', name: 'bndlib', version: '2.4.0'
+    compile group: 'biz.aQute.bnd', name: 'biz.aQute.bndlib', version: '3.1.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/osgi-run-core/src/main/groovy/com/athaydes/gradle/osgi/OsgiConfig.groovy
+++ b/osgi-run-core/src/main/groovy/com/athaydes/gradle/osgi/OsgiConfig.groovy
@@ -84,26 +84,26 @@ class OsgiConfig {
 
     // CONSTANTS
 
-    static final String FELIX = 'org.apache.felix:org.apache.felix.main:4.4.0'
+    static final String FELIX = 'org.apache.felix:org.apache.felix.main:5.4.0'
 
     static final String EQUINOX = 'org.eclipse.osgi:org.eclipse.osgi:3.7.1'
 
     static final String KNOPFLERFISH = 'org.knopflerfish:framework:7.1.2'
 
     static final FELIX_GOGO_BUNDLES = [
-            'org.apache.felix:org.apache.felix.gogo.runtime:0.12.1',
-            'org.apache.felix:org.apache.felix.gogo.shell:0.10.0',
-            'org.apache.felix:org.apache.felix.gogo.command:0.14.0',
+            'org.apache.felix:org.apache.felix.gogo.runtime:0.16.2',
+            'org.apache.felix:org.apache.felix.gogo.shell:0.12.0',
+            'org.apache.felix:org.apache.felix.gogo.command:0.16.0',
     ].asImmutable()
 
     static final IPOJO_BUNDLE = [
-            'org.apache.felix:org.apache.felix.ipojo:1.12.0'
+            'org.apache.felix:org.apache.felix.ipojo:1.12.1'
     ].asImmutable()
 
     static final IPOJO_ALL_BUNDLES = IPOJO_BUNDLE + [
             'org.apache.felix:org.apache.felix.shell:1.4.3',
             'org.apache.felix:org.apache.felix.shell.tui:1.4.1',
-            'org.apache.felix:org.apache.felix.bundlerepository:1.6.0',
+            'org.apache.felix:org.apache.felix.bundlerepository:2.0.6',
             'org.apache.felix:org.apache.felix.ipojo.arch:1.6.0'
     ].asImmutable()
 

--- a/osgi-run-test/build.gradle
+++ b/osgi-run-test/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'com.athaydes.gradle.osgi', name: 'osgi-run-core', version: '1.3.1'
+        classpath group: 'com.athaydes.gradle.osgi', name: 'osgi-run-core', version: '1.4.0'
         classpath group: 'com.athaydes.gradle.osgi', name: 'ipojo-plugin', version: '1.1.1'
     }
 }


### PR DESCRIPTION
At the same time there are new versions for Felix, updated to that version as the default framework and distribution to add by default.

Version number was updated to 1.4.0 to reflect the change.